### PR TITLE
added flutter_switch in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   universal_platform: ^1.0.0+1
   
   yaru_icons: ^0.0.6
+  flutter_switch: ^0.3.2
 
 flutter_icons:
   # android: "launcher_icon"


### PR DESCRIPTION
### Description of the PR:
Added `flutter_switch` in pubspec.yaml

### Reason:
The package `flutter_switch` wasn't present in pubspec.yaml

### Original error message:
```
Error: Couldn't resolve the package 'flutter_switch' in
'package:flutter_switch/flutter_switch.dart'.
lib/pages/backup_restore_page.dart:9:8: Error: Not found:
'package:flutter_switch/flutter_switch.dart'
import 'package:flutter_switch/flutter_switch.dart';
       ^
```